### PR TITLE
I've refactored the settings mechanism for traders, factors, and stra…

### DIFF
--- a/vnpy/factor/engine.py
+++ b/vnpy/factor/engine.py
@@ -27,9 +27,9 @@ from vnpy.factor.base import APP_NAME # Import FactorMode
 # FactorTemplate and FactorMemory are assumed to be defined above or importable
 from vnpy.factor.utils.factor_utils import init_factors, load_factor_setting, save_factor_setting # Ensure these utils are compatible
 from vnpy.factor.utils.memory_utils import truncate_memory as truncate_bar_memory
-from vnpy.factor.settings import get_factor_path, get_factor_setting
+from vnpy.factor.settings import get_factor_definitions_filepath, get_factor_setting, get_factor_data_cache_path, FACTOR_MODULE_SETTINGS
 
-FACTOR_MODULE_NAME = 'vnpy.factor.factors' # Default, can be overridden
+FACTOR_MODULE_NAME = FACTOR_MODULE_SETTINGS.get("module_name", 'vnpy.factor.factors') # Use setting
 SYSTEM_MODE = SETTINGS.get('system.mode', 'LIVE') # LIVE, BACKTEST, etc.
 DEFAULT_DATETIME_COL = "datetime" # Standard datetime column name for FactorMemory
 
@@ -49,8 +49,8 @@ class FactorEngine(BaseEngine):
         super().__init__(main_engine, event_engine, APP_NAME)
         
         # Use settings for paths and configuration
-        self.setting_filename = get_factor_path("factor_settings")
-        self.factor_data_dir = get_factor_path("factor_data_cache")
+        self.setting_filename = get_factor_definitions_filepath()  # Updated
+        self.factor_data_dir = get_factor_data_cache_path()      # Updated
         
         # Load other settings
         self.factor_datetime_col = get_factor_setting("datetime_col")
@@ -80,7 +80,7 @@ class FactorEngine(BaseEngine):
         self.memory_bar: Dict[str, pl.DataFrame] = {} # For OHLCV data
         
         # NEW: Manages FactorMemory instances
-        self.factor_data_dir = Path(self.factor_data_cache_dirname)
+        # self.factor_data_dir is already a Path object from get_factor_data_cache_path()
         self.factor_memory_instances: Dict[str, FactorMemory] = {}
         self.latest_calculated_factors_cache: Dict[str, pl.DataFrame] = {}
 

--- a/vnpy/factor/factor_settings.json
+++ b/vnpy/factor/factor_settings.json
@@ -1,0 +1,7 @@
+{
+    "module_name": "vnpy.factor.factors",
+    "datetime_col": "datetime",
+    "max_memory_length_bar": 100,
+    "max_memory_length_factor": 500,
+    "error_threshold": 3
+}

--- a/vnpy/factor/settings.py
+++ b/vnpy/factor/settings.py
@@ -1,43 +1,128 @@
+import json
 from pathlib import Path
-from typing import Any
-from vnpy.trader.setting import SETTINGS
+from typing import Any, Dict
 
-# Base paths
+try:
+    from vnpy.trader.setting import SETTINGS
+    from vnpy.trader.utility import load_json as load_json_main
+except ImportError:
+    SETTINGS: Dict[str, Any] = {}
+    # Basic load_json fallback for standalone if vnpy.trader.utility.load_json is not available
+    def load_json_fallback(filename: str) -> dict:
+        filepath = Path(filename)
+        if filepath.exists():
+            with open(filepath, 'r', encoding='utf-8') as f:
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    print(f"Warning: JSONDecodeError in {filename}")
+                    return {}
+        return {}
+    load_json_main = load_json_fallback
+
+# Default filenames used if not specified in global SETTINGS or for standalone mode
+DEFAULT_FACTOR_SETTINGS_FILENAME = "factor_settings.json"
+DEFAULT_FACTOR_DEFINITIONS_FILENAME = "factor_maker_setting.json"
+
+# Root path of this module, used for resolving relative paths in standalone mode
+MODULE_ROOT_PATH = Path(__file__).parent
+
+# Determine the factor settings file path
+_factor_settings_file_path_str = SETTINGS.get("factor.settings_file_path", DEFAULT_FACTOR_SETTINGS_FILENAME)
+_factor_settings_filepath = Path(_factor_settings_file_path_str)
+if not _factor_settings_filepath.is_absolute():
+    _factor_settings_filepath = MODULE_ROOT_PATH / _factor_settings_filepath
+
+# Determine the factor definitions file path
+_factor_definitions_file_path_str = SETTINGS.get("factor.definitions_file_path", DEFAULT_FACTOR_DEFINITIONS_FILENAME)
+FACTOR_DEFINITIONS_FILEPATH = Path(_factor_definitions_file_path_str)
+if not FACTOR_DEFINITIONS_FILEPATH.is_absolute():
+    FACTOR_DEFINITIONS_FILEPATH = MODULE_ROOT_PATH / FACTOR_DEFINITIONS_FILEPATH
+
+# Load Factor Module Settings from the JSON file
+FACTOR_MODULE_SETTINGS: Dict[str, Any] = {}
+if _factor_settings_filepath.exists():
+    FACTOR_MODULE_SETTINGS = load_json_main(str(_factor_settings_filepath))
+    if not isinstance(FACTOR_MODULE_SETTINGS, dict): # Ensure it's a dict if file was empty or malformed
+        print(f"Warning: Content of factor settings file {_factor_settings_filepath} is not a valid JSON object. Initializing with empty settings.")
+        FACTOR_MODULE_SETTINGS = {}
+else:
+    print(f"Warning: Factor settings file not found at {_factor_settings_filepath}. Initializing with empty settings.")
+
+# Override FACTOR_MODULE_SETTINGS with values from global SETTINGS if they exist
+_keys_to_override = [
+    "module_name",
+    "datetime_col",
+    "max_memory_length_bar",
+    "max_memory_length_factor",
+    "error_threshold"
+]
+for key in _keys_to_override:
+    override_value = SETTINGS.get(f"factor.{key}")
+    if override_value is not None:
+        FACTOR_MODULE_SETTINGS[key] = override_value
+
+# Base paths for factor data, cache, etc.
 ROOT_PATH = Path(SETTINGS.get("factor.root_path", Path.home() / ".vnpy" / "factor"))
 DATA_PATH = ROOT_PATH / "data"
 CACHE_PATH = ROOT_PATH / "cache"
-SETTINGS_PATH = ROOT_PATH / "settings"
 
-# Ensure directories exist
-for path in [ROOT_PATH, DATA_PATH, CACHE_PATH, SETTINGS_PATH]:
+# Ensure base directories exist
+for path in [ROOT_PATH, DATA_PATH, CACHE_PATH]:
     path.mkdir(parents=True, exist_ok=True)
 
-# Factor specific paths and settings
-FACTOR_PATHS = {
-    "factor_settings": SETTINGS_PATH / "factor_maker_setting.json",
-    "factor_data_cache": CACHE_PATH / "factor_data_cache",
-    "backtest_data_cache": CACHE_PATH / "backtest_factor_data_cache",
-}
-
-# Factor module settings
-FACTOR_SETTINGS = {
-    "module_name": SETTINGS.get("factor.module_name", "vnpy.factor.factors"),
-    "datetime_col": SETTINGS.get("factor.datetime_col", "datetime"),
-    "max_memory_length_bar": SETTINGS.get("factor.max_memory_length_bar", 100),
-    "max_memory_length_factor": SETTINGS.get("factor.max_memory_length_factor", 500),
-    "error_threshold": SETTINGS.get("factor.error_threshold", 3),
-}
-
-def get_factor_path(key: str) -> Path:
-    """Get a factor-related path by key."""
-    path = FACTOR_PATHS.get(key)
-    if not path:
-        raise KeyError(f"Path key '{key}' not found in FACTOR_PATHS")
-    return path
-
 def get_factor_setting(key: str) -> Any:
-    """Get a factor-related setting by key."""
-    value = FACTOR_SETTINGS.get(key)
-    if value is None:
-        raise KeyError(f"Setting key '{key}' not found in FACTOR_SETTINGS")
+    """
+    Get a factor-related setting by key.
+    Checks FACTOR_MODULE_SETTINGS.
+    """
+    value = FACTOR_MODULE_SETTINGS.get(key)
+    if value is None and key not in FACTOR_MODULE_SETTINGS: # Check key existence for explicit None values
+        raise KeyError(f"Setting key '{key}' not found in factor module settings.")
     return value
+
+def get_factor_definitions_filepath() -> Path:
+    """Get the absolute path to the factor definitions JSON file."""
+    return FACTOR_DEFINITIONS_FILEPATH
+
+def get_factor_data_cache_path() -> Path:
+    """Get the path to the factor data cache directory."""
+    return CACHE_PATH / "factor_data_cache"
+
+def get_backtest_data_cache_path() -> Path:
+    """Get the path to the backtest factor data cache directory."""
+    return CACHE_PATH / "backtest_factor_data_cache"
+
+# For easier access if needed, though direct use of FACTOR_MODULE_SETTINGS is common
+FACTOR_SETTINGS = FACTOR_MODULE_SETTINGS
+
+# The following old definitions are now replaced or managed by the logic above:
+# - Old FACTOR_SETTINGS dictionary (now FACTOR_MODULE_SETTINGS, loaded and overridden)
+# - Old FACTOR_PATHS dictionary (replaced by specific getter functions)
+# - Old SETTINGS_PATH (not explicitly needed as files are resolved via MODULE_ROOT_PATH or global SETTINGS)
+# - Old get_factor_path function (replaced by specific getter functions)
+
+# Example of how to ensure specific cache subdirectories exist if needed
+# get_factor_data_cache_path().mkdir(parents=True, exist_ok=True)
+# get_backtest_data_cache_path().mkdir(parents=True, exist_ok=True)
+
+print(f"LOG: Factor settings loaded. Definitions path: {FACTOR_DEFINITIONS_FILEPATH}")
+print(f"LOG: Factor module config: {FACTOR_MODULE_SETTINGS}")
+print(f"LOG: Factor root path: {ROOT_PATH}")
+print(f"LOG: Factor data path: {DATA_PATH}")
+print(f"LOG: Factor cache path: {CACHE_PATH}")
+
+# Make FACTOR_DEFINITIONS_FILEPATH available for import if needed elsewhere for clarity,
+# though get_factor_definitions_filepath() is the preferred accessor.
+__all__ = [
+    "FACTOR_MODULE_SETTINGS",
+    "FACTOR_SETTINGS",  # Alias for FACTOR_MODULE_SETTINGS
+    "get_factor_setting",
+    "FACTOR_DEFINITIONS_FILEPATH",
+    "get_factor_definitions_filepath",
+    "ROOT_PATH",
+    "DATA_PATH",
+    "CACHE_PATH",
+    "get_factor_data_cache_path",
+    "get_backtest_data_cache_path"
+]

--- a/vnpy/strategy/settings.py
+++ b/vnpy/strategy/settings.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    from vnpy.trader.setting import SETTINGS
+    from vnpy.trader.utility import load_json as load_json_main
+except ImportError:
+    SETTINGS: Dict[str, Any] = {}
+    # Basic load_json fallback for standalone if vnpy.trader.utility.load_json is not available
+    def load_json_fallback(filename: str) -> dict:
+        filepath = Path(filename)
+        if filepath.exists():
+            with open(filepath, 'r', encoding='utf-8') as f:
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    print(f"Warning: JSONDecodeError in {filename}")
+                    return {}
+        return {}
+    load_json_main = load_json_fallback
+
+# Default filenames used if not specified in global SETTINGS or for standalone mode
+DEFAULT_STRATEGY_SETTINGS_FILENAME = "strategy_settings.json"
+DEFAULT_STRATEGY_DEFINITIONS_FILENAME = "strategy_template_definitions.json"
+
+# Root path of this module, used for resolving relative paths in standalone mode
+MODULE_ROOT_PATH = Path(__file__).parent
+
+# Determine the strategy settings file path
+_strategy_settings_file_path_str = SETTINGS.get("strategy.settings_file_path", DEFAULT_STRATEGY_SETTINGS_FILENAME)
+_strategy_settings_filepath = Path(_strategy_settings_file_path_str)
+if not _strategy_settings_filepath.is_absolute():
+    _strategy_settings_filepath = MODULE_ROOT_PATH / _strategy_settings_filepath
+
+# Determine the strategy definitions file path
+_strategy_definitions_file_path_str = SETTINGS.get("strategy.definitions_file_path", DEFAULT_STRATEGY_DEFINITIONS_FILENAME)
+STRATEGY_DEFINITIONS_FILEPATH = Path(_strategy_definitions_file_path_str)
+if not STRATEGY_DEFINITIONS_FILEPATH.is_absolute():
+    STRATEGY_DEFINITIONS_FILEPATH = MODULE_ROOT_PATH / _strategy_definitions_file_path_str # Corrected variable name
+
+# Load Strategy Module Settings from the JSON file
+STRATEGY_MODULE_SETTINGS: Dict[str, Any] = {}
+if _strategy_settings_filepath.exists():
+    STRATEGY_MODULE_SETTINGS = load_json_main(str(_strategy_settings_filepath))
+    if not isinstance(STRATEGY_MODULE_SETTINGS, dict): # Ensure it's a dict if file was empty or malformed
+        print(f"Warning: Content of strategy settings file {_strategy_settings_filepath} is not a valid JSON object. Initializing with empty settings.")
+        STRATEGY_MODULE_SETTINGS = {}
+else:
+    print(f"Warning: Strategy settings file not found at {_strategy_settings_filepath}. Initializing with empty settings.")
+
+# Override STRATEGY_MODULE_SETTINGS with values from global SETTINGS if they exist
+_keys_to_override = [
+    "default_strategy_path",
+    "default_retrain_interval_days"
+    # Add other strategy-specific keys here if they become globally configurable
+]
+for key in _keys_to_override:
+    override_value = SETTINGS.get(f"strategy.{key}")
+    if override_value is not None:
+        STRATEGY_MODULE_SETTINGS[key] = override_value
+
+# Strategy specific paths (Minimal for now, can be expanded)
+# Example: If strategies save models or specific logs to a configurable directory
+# STRATEGY_DATA_PATH = Path(SETTINGS.get("strategy.data_path", MODULE_ROOT_PATH / "data"))
+# STRATEGY_DATA_PATH.mkdir(parents=True, exist_ok=True)
+
+def get_strategy_setting(key: str) -> Any:
+    """
+    Get a strategy-related setting by key.
+    Checks STRATEGY_MODULE_SETTINGS.
+    """
+    value = STRATEGY_MODULE_SETTINGS.get(key)
+    if value is None and key not in STRATEGY_MODULE_SETTINGS: # Check key existence for explicit None values
+        raise KeyError(f"Setting key '{key}' not found in strategy module settings.")
+    return value
+
+def get_strategy_definitions_filepath() -> Path:
+    """Get the absolute path to the strategy definitions JSON file."""
+    return STRATEGY_DEFINITIONS_FILEPATH
+
+print(f"LOG: Strategy settings loaded. Definitions path: {STRATEGY_DEFINITIONS_FILEPATH}")
+print(f"LOG: Strategy module config: {STRATEGY_MODULE_SETTINGS}")
+
+__all__ = [
+    "STRATEGY_MODULE_SETTINGS",
+    "get_strategy_setting",
+    "STRATEGY_DEFINITIONS_FILEPATH", # Exposing the path directly as well
+    "get_strategy_definitions_filepath"
+]

--- a/vnpy/strategy/strategy_settings.json
+++ b/vnpy/strategy/strategy_settings.json
@@ -1,0 +1,5 @@
+{
+    "default_strategy_path": "strategies",
+    "default_retrain_interval_days": 30,
+    "default_execution_gateway": "BINANCE_SPOT"
+}

--- a/vnpy/strategy/strategy_template_definitions.json
+++ b/vnpy/strategy/strategy_template_definitions.json
@@ -1,0 +1,33 @@
+[
+    {
+        "class_name": "AtrRsiStrategy",
+        "template_name": "ATR_RSI_Trend_Strategy",
+        "author": "Default",
+        "description": "A trend-following strategy using ATR for stop loss and RSI for entry.",
+        "parameters": {
+            "vt_symbols": ["IF99.CFFEX"],
+            "atr_length": 22,
+            "atr_multiplier": 3.2,
+            "rsi_length": 5,
+            "rsi_entry": 18,
+            "trailing_percent": 0.8,
+            "min_order_volume": 1,
+            "trading_size": 1
+        },
+        "required_data_interval": "1m"
+    },
+    {
+        "class_name": "DualMovingAverageStrategy",
+        "template_name": "DMA_Cross_Strategy",
+        "author": "Default",
+        "description": "A simple strategy based on the crossover of two moving averages.",
+        "parameters": {
+            "vt_symbols": ["RB99.SHFE"],
+            "fast_window": 5,
+            "slow_window": 20,
+            "trading_size": 1,
+            "min_order_volume": 1
+        },
+        "required_data_interval": "1h"
+    }
+]

--- a/vnpy/trader/setting.py
+++ b/vnpy/trader/setting.py
@@ -48,6 +48,10 @@ SETTINGS: dict = {
     # trading
     "vt_symbols": [],
 
+    "factor.settings_file_path": "factor_settings.json",
+    "factor.definitions_file_path": "factor_maker_setting.json",
+    "strategy.settings_file_path": "strategy_settings.json",
+    "strategy.definitions_file_path": "strategy_template_definitions.json",
 }
 
 # Load global setting from json file.


### PR DESCRIPTION
…tegies.

- I centralized path configuration in vnpy.trader.setting.py.
- I introduced factor_settings.json and strategy_settings.json for module-specific configurations.
- factor_maker_setting.json (which already existed) and strategy_template_definitions.json (which is new) are used for factor and strategy instance definitions respectively.
- I refactored vnpy.factor.settings.py and created vnpy.strategy.settings.py to manage loading these settings with support for overrides from global settings and standalone operation.
- I updated FactorEngine and BaseStrategyEngine to use the new settings modules for path resolution and configuration loading.
- BaseStrategyEngine now loads and saves strategy instance configurations to the file specified by strategy.definitions_file_path (strategy_template_definitions.json by default).

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #