### PR TITLE
feat: Add factor parameter optimization to BacktestEngine

### DIFF
--- a/vnpy/factor/optimizer.py
+++ b/vnpy/factor/optimizer.py
@@ -1,0 +1,155 @@
+# File: vnpy/factor/optimizer.py
+
+from __future__ import annotations # For forward reference of BacktestEngine if needed
+
+import numpy as np
+from sklearn.base import BaseEstimator
+from typing import Dict, Any, Optional, TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    # This avoids circular import issues if BacktestEngine might import this file later,
+    # or for cleaner type hinting.
+    from vnpy.factor.backtesting.backtesting import BacktestEngine
+
+from logging import INFO, DEBUG, WARNING, ERROR # For log levels
+import polars as pl
+
+
+class FactorBacktestEstimator(BaseEstimator):
+    """
+    A scikit-learn compatible custom estimator for factor parameter optimization
+    using GridSearchCV within the VnPy factor backtesting engine.
+    """
+
+    def __init__(
+        self,
+        backtesting_engine: BacktestEngine,
+        factor_class_name: str,
+        full_bar_data_for_slicing: Dict[str, pl.DataFrame], # New parameter
+        **factor_params: Any
+    ):
+        self.backtesting_engine = backtesting_engine
+        self.factor_class_name = factor_class_name
+        self.full_bar_data_for_slicing = full_bar_data_for_slicing # Store this
+        
+        self._factor_param_names: List[str] = []
+        for key, value in factor_params.items():
+            setattr(self, key, value)
+            self._factor_param_names.append(key)
+        
+        self.current_score: float = -np.inf
+
+    # get_params and set_params will be inherited from BaseEstimator.
+    # BaseEstimator's get_params collects all __init__ parameters.
+    # BaseEstimator's set_params updates attributes directly.
+
+    def fit(self, X_indices_for_fold: np.ndarray, y: Any = None) -> FactorBacktestEstimator:
+        self.current_score = -np.inf
+
+        current_factor_params_for_trial = {
+            key: getattr(self, key) for key in self._factor_param_names
+        }
+        
+        self.backtesting_engine.write_log(f"Estimator.fit: Class '{self.factor_class_name}', Params: {current_factor_params_for_trial}", DEBUG)
+
+        # Helper to slice the dict of DataFrames
+        def slice_bar_data_dict(bar_data_dict: Dict[str, pl.DataFrame], slice_indices: np.ndarray) -> Dict[str, pl.DataFrame]:
+            sliced_dict = {}
+            if not bar_data_dict or not isinstance(slice_indices, np.ndarray) or slice_indices.size == 0:
+                self.backtesting_engine.write_log("slice_bar_data_dict: Invalid input or empty indices.", WARNING)
+                return sliced_dict # Return empty if inputs are problematic
+
+            for key, df in bar_data_dict.items():
+                if isinstance(df, pl.DataFrame) and not df.is_empty():
+                    if slice_indices.max() < df.height:
+                        sliced_dict[key] = df[slice_indices]
+                    else:
+                        self.backtesting_engine.write_log(f"slice_bar_data_dict: Indices out of bounds for key {key}. Max index: {slice_indices.max()}, DF height: {df.height}", WARNING)
+                        # Return empty dict if any slice fails, to signal data issue for this fold.
+                        return {} 
+                else:
+                    # Pass through non-DF or empty DF as is, or handle more strictly if needed
+                    # For now, passing through allows flexibility if some dict items aren't main bar data
+                    sliced_dict[key] = df 
+            return sliced_dict
+
+        current_data_slice_dict = slice_bar_data_dict(self.full_bar_data_for_slicing, X_indices_for_fold)
+
+        if not current_data_slice_dict or "close" not in current_data_slice_dict or current_data_slice_dict["close"].is_empty():
+            self.backtesting_engine.write_log("Estimator.fit: Data slice is invalid or 'close' data is missing/empty after slicing.", ERROR)
+            return self
+
+        # Configure BacktestEngine for Data Slice (current_data_slice_dict)
+        dt_col_name = self.backtesting_engine.factor_datetime_col
+        if dt_col_name not in current_data_slice_dict["close"].columns:
+            self.backtesting_engine.write_log(f"Estimator.fit: Datetime col '{dt_col_name}' not in sliced X['close'].", ERROR)
+            return self
+            
+        current_vt_symbols = [col for col in current_data_slice_dict["close"].columns if col != dt_col_name]
+        if not current_vt_symbols:
+            self.backtesting_engine.write_log("Estimator.fit: No symbol columns in sliced X['close'].", ERROR)
+            return self
+
+        self.backtesting_engine.memory_bar = {k: v.clone() for k, v in current_data_slice_dict.items() if isinstance(v, pl.DataFrame)}
+        self.backtesting_engine.num_data_rows = current_data_slice_dict["close"].height
+        
+        # Clear previous run's factor-specific data
+        self.backtesting_engine.stacked_factors.clear()
+        self.backtesting_engine.flattened_factors.clear()
+        self.backtesting_engine.sorted_factor_keys.clear()
+        self.backtesting_engine.dask_tasks.clear()
+        self.backtesting_engine.factor_memory_instances.clear()
+
+        # Prepare Factor Definition
+        factor_definition_dict = {
+            "class_name": self.factor_class_name,
+            "factor_name": self.factor_class_name, 
+            "params": current_factor_params_for_trial,
+        }
+
+        # Execute Backtesting Pipeline
+        if not self.backtesting_engine.init_single_factor(factor_definition_dict, vt_symbols_for_factor=current_vt_symbols):
+            self.backtesting_engine.write_log("Estimator.fit: init_single_factor failed.", WARNING); return self
+        factor_data_df = self.backtesting_engine.calculate_single_factor_data()
+        if factor_data_df is None or factor_data_df.is_empty():
+            self.backtesting_engine.write_log("Estimator.fit: Factor calculation failed/empty.", WARNING); return self
+        if not self.backtesting_engine.prepare_symbol_returns(reference_datetime_series=current_data_slice_dict["close"][dt_col_name]):
+            self.backtesting_engine.write_log("Estimator.fit: Preparing symbol returns failed.", WARNING); return self
+        if not self.backtesting_engine.perform_long_short_analysis(factor_data_df):
+            self.backtesting_engine.write_log("Estimator.fit: L-S analysis failed.", WARNING); return self
+        if hasattr(self.backtesting_engine, 'long_short_portfolio_returns_df') and \
+           self.backtesting_engine.long_short_portfolio_returns_df is not None and \
+           not self.backtesting_engine.long_short_portfolio_returns_df.is_empty():
+            if not self.backtesting_engine.calculate_performance_metrics():
+                self.backtesting_engine.write_log("Estimator.fit: Metrics calculation failed.", WARNING); return self
+        else:
+            self.backtesting_engine.write_log("Estimator.fit: L-S returns unavailable, skipping metrics.", INFO); return self
+
+        # Store Score
+        if hasattr(self.backtesting_engine, 'performance_metrics') and self.backtesting_engine.performance_metrics:
+            sharpe_ratio = self.backtesting_engine.performance_metrics.get('sharpe')
+            if sharpe_ratio is not None and np.isfinite(sharpe_ratio):
+                self.current_score = sharpe_ratio
+                self.backtesting_engine.write_log(f"Estimator.fit successful. Sharpe: {self.current_score:.4f}", DEBUG)
+            else:
+                self.current_score = -np.inf
+                self.backtesting_engine.write_log(f"Estimator.fit: Sharpe None/non-finite ({sharpe_ratio}). Score -inf.", DEBUG)
+        else:
+            self.current_score = -np.inf
+            self.backtesting_engine.write_log("Estimator.fit: No metrics. Score -inf.", DEBUG)
+        
+        return self
+
+    def score(self, X: Any, y: Any = None) -> float:
+        """
+        Returns the score (e.g., Sharpe Ratio) calculated by the last `fit` call.
+        This method will be called by GridSearchCV after `fit`.
+
+        Args:
+            X: Data slice (not directly used here as score is based on last fit).
+            y: Target variable (not used).
+            
+        Returns:
+            The calculated score (e.g., Sharpe Ratio).
+        """
+        return self.current_score

--- a/vnpy/factor/tests/test_single_factor_engine.py
+++ b/vnpy/factor/tests/test_single_factor_engine.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 from pathlib import Path
 import tempfile
 import shutil
@@ -10,6 +10,9 @@ from typing import Dict, Any
 from vnpy.factor.template import FactorTemplate, FactorParameters
 from vnpy.trader.constant import Interval
 from vnpy.factor.backtesting.backtesting import BacktestEngine, DEFAULT_DATETIME_COL
+from vnpy.factor.optimizer import FactorBacktestEstimator
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit # For patching
+import numpy as np
 
 class MockFactor(FactorTemplate):
     factor_name = "mockfactor"
@@ -191,6 +194,181 @@ class TestSingleFactorEngine(unittest.TestCase):
             self.assertIn("sharpe", self.engine.performance_metrics)
             # Sharpe can be 0 or NaN depending on returns variance.
             # self.assertIsNotNone(self.engine.performance_metrics.get("sharpe"), "Sharpe ratio should not be None/NaN")
+
+    def test_factor_backtest_estimator_fit_score(self):
+        """Test FactorBacktestEstimator's fit and score methods."""
+        mock_engine_instance = MagicMock(spec=BacktestEngine)
+        mock_engine_instance.factor_datetime_col = DEFAULT_DATETIME_COL
+        # Mock write_log to prevent console output during tests unless debugging
+        mock_engine_instance.write_log = MagicMock()
+
+
+        mock_full_bar_data = {
+            "close": pl.DataFrame({
+                DEFAULT_DATETIME_COL: [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023,1,3)],
+                "SYM1.TEST": [10.0, 10.1, 10.2],
+                "SYM2.TEST": [20.0, 20.1, 20.2]
+            }),
+            "open": pl.DataFrame({ # Estimator's fit logic expects dict of DFs, so provide more keys
+                DEFAULT_DATETIME_COL: [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023,1,3)],
+                "SYM1.TEST": [9.9, 10.0, 10.1],
+                "SYM2.TEST": [19.9, 20.0, 20.1]
+            })
+        }
+        initial_factor_params = {"window": 10, "fixed_param": 5}
+
+        estimator = FactorBacktestEstimator(
+            backtesting_engine=mock_engine_instance,
+            factor_class_name="MockFactor", # Assuming MockFactor is defined in the test file
+            full_bar_data_for_slicing=mock_full_bar_data,
+            **initial_factor_params
+        )
+
+        # Test if initial params are set
+        self.assertEqual(estimator.window, 10)
+        self.assertEqual(estimator.fixed_param, 5)
+
+        # Simulate GridSearchCV setting a parameter
+        estimator.set_params(window=20)
+        self.assertEqual(estimator.window, 20) # Check if set_params worked
+
+        mock_indices = np.array([0, 1]) # Slice first two rows
+
+        # Configure mock engine's methods
+        mock_engine_instance.init_single_factor.return_value = True
+        
+        # Dummy factor data DF needs to match the symbols in the sliced data and datetime col
+        # Sliced data will have SYM1.TEST, SYM2.TEST
+        dummy_factor_output_df = pl.DataFrame({
+            DEFAULT_DATETIME_COL: mock_full_bar_data["close"][DEFAULT_DATETIME_COL][mock_indices],
+            "SYM1.TEST": [0.5, 0.6],
+            "SYM2.TEST": [-0.2, 0.3]
+        })
+        mock_engine_instance.calculate_single_factor_data.return_value = dummy_factor_output_df
+        mock_engine_instance.prepare_symbol_returns.return_value = True
+        mock_engine_instance.perform_long_short_analysis.return_value = True
+        mock_engine_instance.calculate_performance_metrics.return_value = True
+        
+        # Using PropertyMock if performance_metrics is a property, else direct assignment
+        # For this subtask, assuming performance_metrics is a direct attribute that can be set.
+        # If it's a @property, then:
+        # type(mock_engine_instance).performance_metrics = PropertyMock(return_value={"sharpe": 1.23})
+        # For now, direct assignment as per current BacktestEngine structure:
+        mock_engine_instance.performance_metrics = {"sharpe": 1.23}
+
+
+        result_estimator = estimator.fit(X_indices_for_fold=mock_indices)
+        self.assertIs(result_estimator, estimator) # fit should return self
+
+        # Assert init_single_factor was called
+        mock_engine_instance.init_single_factor.assert_called_once()
+        args, kwargs = mock_engine_instance.init_single_factor.call_args
+        
+        # Check factor_definition argument
+        called_factor_def = kwargs.get('factor_definition') 
+        if called_factor_def is None and args: called_factor_def = args[0] # if passed as positional
+        
+        self.assertIsNotNone(called_factor_def)
+        self.assertEqual(called_factor_def.get("class_name"), "MockFactor")
+        self.assertEqual(called_factor_def.get("params", {}).get("window"), 20) # Updated by set_params
+        self.assertEqual(called_factor_def.get("params", {}).get("fixed_param"), 5) # From initial_factor_params
+
+        # Check vt_symbols_for_factor argument (should be derived from sliced data)
+        called_symbols = kwargs.get('vt_symbols_for_factor')
+        if called_symbols is None and len(args) > 1: called_symbols = args[1]
+
+        self.assertEqual(set(called_symbols), {"SYM1.TEST", "SYM2.TEST"})
+
+
+        self.assertEqual(estimator.current_score, 1.23)
+        self.assertEqual(estimator.score(None), 1.23)
+        
+        # Test case where Sharpe is None or non-finite
+        mock_engine_instance.performance_metrics = {"sharpe": np.nan}
+        estimator.fit(X_indices_for_fold=mock_indices)
+        self.assertEqual(estimator.current_score, -np.inf)
+
+
+    @patch('vnpy.factor.backtesting.backtesting.GridSearchCV') # Patch where GridSearchCV is USED
+    @patch('vnpy.factor.backtesting.backtesting.TimeSeriesSplit') # Patch where TimeSeriesSplit is USED
+    def test_engine_optimize_factor_parameters(self, MockTimeSeriesSplit, MockGridSearchCV):
+        """Test BacktestEngine's optimize_factor_parameters method."""
+        
+        # Configure MockTimeSeriesSplit
+        mock_ts_splitter_instance = MockTimeSeriesSplit.return_value
+        
+        # Configure MockGridSearchCV
+        mock_grid_search_instance = MockGridSearchCV.return_value
+        mock_grid_search_instance.fit.return_value = None # or mock_grid_search_instance
+        mock_grid_search_instance.best_params_ = {"window": 25}
+        mock_grid_search_instance.best_score_ = 1.55
+        mock_grid_search_instance.cv_results_ = {
+            "mean_test_score": np.array([1.55, 1.45]), 
+            "std_test_score": np.array([0.1, 0.05]),
+            "params": [{"window": 25}, {"window": 15}]
+        }
+
+        # Prepare data for the engine method
+        # self.engine is from setUp, already has load_bar_data patched.
+        # optimize_factor_parameters expects full_bar_data directly.
+        test_full_bar_data = {
+            "close": pl.DataFrame({
+                DEFAULT_DATETIME_COL: [datetime(2023, 1, i+1) for i in range(20)], # 20 days of data
+                "SYM1.TEST": [100 + i for i in range(20)],
+                "SYM2.TEST": [200 - i for i in range(20)]
+            }),
+            "open": pl.DataFrame({
+                 DEFAULT_DATETIME_COL: [datetime(2023, 1, i+1) for i in range(20)],
+                "SYM1.TEST": [99 + i for i in range(20)],
+                "SYM2.TEST": [199 - i for i in range(20)]
+            })
+        }
+        
+        initial_settings = {"window": 10, "period": 30} # 'period' is a fixed param here
+        param_grid = {"window": [15, 25]} # 'window' is the param to optimize
+        
+        # Call the method to test
+        n_cv_splits = 3
+        best_params_result = self.engine.optimize_factor_parameters(
+            factor_class_name="MockFactor", 
+            initial_factor_settings=initial_settings,
+            parameter_grid=param_grid,
+            full_bar_data=test_full_bar_data,
+            n_splits_for_cv=n_cv_splits
+        )
+
+        # Assertions
+        MockTimeSeriesSplit.assert_called_once_with(n_splits=n_cv_splits)
+        
+        MockGridSearchCV.assert_called_once()
+        args_gscv, kwargs_gscv = MockGridSearchCV.call_args
+        
+        self.assertIsInstance(kwargs_gscv['estimator'], FactorBacktestEstimator)
+        self.assertEqual(kwargs_gscv['estimator'].factor_class_name, "MockFactor")
+        self.assertEqual(kwargs_gscv['estimator'].window, 10) # Initial window
+        self.assertEqual(kwargs_gscv['estimator'].period, 30) # Initial fixed param
+        self.assertIs(kwargs_gscv['estimator'].full_bar_data_for_slicing, test_full_bar_data)
+        
+        self.assertEqual(kwargs_gscv['param_grid'], param_grid)
+        self.assertIs(kwargs_gscv['cv'], mock_ts_splitter_instance)
+        self.assertEqual(kwargs_gscv['n_jobs'], 1) # Hardcoded in optimize_factor_parameters
+
+        mock_grid_search_instance.fit.assert_called_once()
+        # Check X passed to grid_search.fit (should be np.arange(num_samples))
+        args_fit, _ = mock_grid_search_instance.fit.call_args
+        expected_indices = np.arange(test_full_bar_data["close"].height)
+        np.testing.assert_array_equal(args_fit[0], expected_indices)
+
+        self.assertEqual(best_params_result, {"window": 25})
+        
+        self.assertIsNotNone(self.engine.optimization_results)
+        if self.engine.optimization_results: # For type checker
+            self.assertEqual(self.engine.optimization_results["best_score"], 1.55)
+            self.assertEqual(self.engine.optimization_results["best_params"], {"window": 25})
+            self.assertIn("cv_results_summary", self.engine.optimization_results)
+            summary = self.engine.optimization_results["cv_results_summary"]
+            self.assertEqual(summary["mean_test_score"], [1.55, 1.45]) # Check .tolist() conversion
+            self.assertEqual(summary["params"], ['{\'window\': 25}', '{\'window\': 15}']) # Check str(p) conversion
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a factor parameter optimization workflow using scikit-learn's GridSearchCV within the BacktestEngine. This allows you to find optimal parameters for individual factors based on a specified objective metric (e.g., Sharpe Ratio of a long-short portfolio).

Key additions and changes:

1.  **`FactorBacktestEstimator` (`vnpy.factor.optimizer.py`):**
    *   A new scikit-learn compatible estimator class.
    *   `__init__`: Takes a BacktestEngine instance, factor class name,
        initial factor parameters, and the full bar data for slicing.
    *   `fit()`: Executes the single factor backtesting pipeline (factor
        calculation, L-S portfolio, Sharpe ratio) on a data slice
        (provided by TimeSeriesSplit via GridSearchCV) using the
        BacktestEngine instance. Stores the calculated Sharpe ratio.
    *   `score()`: Returns the stored Sharpe ratio.

2.  **`BacktestEngine` (`vnpy.factor.backtesting.backtesting.py`):**
    *   New method `optimize_factor_parameters()`:
        *   Orchestrates the optimization process.
        *   Initializes `FactorBacktestEstimator`.
        *   Uses `sklearn.model_selection.TimeSeriesSplit` for robust
            cross-validation on time-series data.
        *   Employs `sklearn.model_selection.GridSearchCV` to search the
            defined parameter grid, using the estimator and splitter.
        *   `n_jobs` for GridSearchCV is set to 1 to ensure serial
            execution due to the shared BacktestEngine state.
        *   Stores optimization results (best parameters, best score,
            CV summary) in `self.optimization_results`.
    *   Enhanced `run_single_factor_backtest()`:
        *   New parameters to enable and configure optimization
            (`perform_optimization`, `parameter_grid`, etc.).
        *   If optimization is enabled, it first loads the full dataset,
            then splits it into a main training set and a final hold-out
            test set (using `_split_data_dict` helper).
        *   Calls `optimize_factor_parameters()` on the training set.
        *   Uses the best parameters found to run a final backtest on
            the test set (or full set if no test split).
        *   If optimization is disabled, it performs a single backtest run
            as previously implemented.
    *   Updated `generate_single_factor_report()`:
        *   Includes an "parameter_optimization_summary" section in the
            report if optimization was performed, detailing best parameters,
            score, and CV results summary.
    *   New private static helper `_split_data_dict()` for splitting
        the bar data dictionary (train/test).

3.  **Unit Tests (`vnpy.factor.tests.test_single_factor_engine.py`):**
    *   Added tests for `FactorBacktestEstimator` (init, fit, score),
        mocking BacktestEngine calls within `fit`.
    *   Added tests for `BacktestEngine.optimize_factor_parameters`,
        mocking `GridSearchCV` and `TimeSeriesSplit` to verify
        correct setup and interaction.

This major enhancement provides a systematic way to tune factor parameters, improving the factor development and evaluation process within VnPy.

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #