### PR TITLE
Refactor: Remove redundant DEBUG logs in factor backtesting

### DIFF
--- a/vnpy/factor/backtesting/backtesting.py
+++ b/vnpy/factor/backtesting/backtesting.py
@@ -66,7 +66,7 @@ class BacktestEngine:
             self.module_factors = importlib.import_module(self.factor_module_name)
             self._write_log(
                 f"Successfully imported factor module: '{self.factor_module_name}'",
-                level=INFO,
+                level=DEBUG,
             )
         except ImportError as e:
             self._write_log(
@@ -92,7 +92,7 @@ class BacktestEngine:
         """
         self._write_log(
             f"Orchestrator Placeholder: load_bar_data called for {start} to {end}, interval {interval.value}, symbols: {vt_symbols}",
-            level=INFO,
+            level=DEBUG,
         )
         self.memory_bar.clear()
 
@@ -216,7 +216,7 @@ class BacktestEngine:
 
         self._write_log(
             f"Orchestrator Placeholder: Successfully simulated loading of {self.num_data_rows} rows for {len(vt_symbols)} symbols.",
-            level=INFO,
+            level=DEBUG,
         )
         return True
 
@@ -406,7 +406,7 @@ class BacktestEngine:
         vt_symbols_for_run: list[str],  # Pass the current run's symbols
     ) -> pl.DataFrame | None:
         """Uses the calculator to compute factor values using its loaded data."""
-        self._write_log("Starting factor value computation phase...", level=INFO)
+        self._write_log("Starting factor value computation phase...", level=DEBUG)
 
         factor_df = calculator.compute_factor_values(
             target_factor_instance_input=target_factor_instance,
@@ -430,7 +430,7 @@ class BacktestEngine:
         report_filename_prefix: str,
     ) -> Path | None:
         """Uses the analyser to process results and generate a report."""
-        self._write_log("Starting factor analysis phase...", level=INFO)
+        self._write_log("Starting factor analysis phase...", level=DEBUG)
         analyser = FactorAnalyser(
             output_data_dir_for_reports=self.output_data_dir_for_analyser_reports
         )

--- a/vnpy/factor/backtesting/factor_analyzer.py
+++ b/vnpy/factor/backtesting/factor_analyzer.py
@@ -194,14 +194,13 @@ class FactorAnalyser:
                 "Analysis data is empty after joining factors and returns.", level=ERROR
             )
             return None
-        self._write_log("Analysis data prepared successfully.", level=INFO)
         return analysis_data
 
     def perform_quantile_analysis(self, analysis_data: pl.DataFrame) -> bool:
         """Performs quantile analysis on the prepared data."""
         self._write_log(
             f"Performing quantile analysis ({self.config.num_quantiles} quantiles)...",
-            level=INFO,
+            level=DEBUG,
         )
         if analysis_data.is_empty():
             self._write_log(
@@ -238,7 +237,6 @@ class FactorAnalyser:
             by_time=quantile_returns_by_time,
             overall_average=average_quantile_returns_overall,
         )
-        self._write_log("Quantile analysis completed.", level=INFO)
         return True
 
     def perform_long_short_analysis(self, analysis_data: pl.DataFrame) -> bool:
@@ -246,7 +244,7 @@ class FactorAnalyser:
         percentile = self.config.long_short_percentile
         self._write_log(
             f"Performing L/S analysis (top/bottom {percentile * 100:.0f}%)...",
-            level=INFO,
+            level=DEBUG,
         )
         if analysis_data.is_empty():
             self._write_log("Analysis data is empty for L/S analysis.", level=ERROR)
@@ -327,7 +325,7 @@ class FactorAnalyser:
         """Calculates a comprehensive suite of performance metrics using QuantStats."""
         self._write_log(
             "Calculating full suite of performance metrics with QuantStats...",
-            level=INFO,
+            level=DEBUG,
         )
         if (
             self.long_short_portfolio_returns_df is None
@@ -386,7 +384,6 @@ class FactorAnalyser:
                 )
                 for k, v in self.performance_metrics.to_dict().items()
             }
-            self._write_log("QuantStats performance metrics calculated.", level=INFO)
             return True
         except Exception as e:
             self._write_log(
@@ -464,7 +461,7 @@ class FactorAnalyser:
         benchmark_symbol: str | None = None,
     ) -> Path | None:
         """Generates and saves a comprehensive HTML report using QuantStats."""
-        self._write_log("Generating interactive HTML report...", level=INFO)
+        self._write_log("Generating interactive HTML report...", level=DEBUG)
         if self.long_short_portfolio_returns_df is None:
             self._write_log(
                 "L/S portfolio returns not available for HTML report.", level=ERROR

--- a/vnpy/factor/backtesting/factor_calculator.py
+++ b/vnpy/factor/backtesting/factor_calculator.py
@@ -83,9 +83,6 @@ class FactorCalculator:
     def _prepare_output_directory(self) -> None:
         try:
             self.output_data_dir.mkdir(parents=True, exist_ok=True)
-            self._write_log(
-                f"Factor cache directory ensured at: {self.output_data_dir}", level=INFO
-            )
         except OSError as e:
             self._write_log(
                 f"Error creating factor cache directory {self.output_data_dir}: {e}. Critical error.",
@@ -239,7 +236,7 @@ class FactorCalculator:
     def _initialize_factor_memory(self) -> bool:
         self._write_log(
             f"Initializing factor memory for {len(self.sorted_factor_keys)} factors...",
-            level=INFO,
+            level=DEBUG,
         )
         if self.num_data_rows <= 0:
             self._write_log(
@@ -281,10 +278,6 @@ class FactorCalculator:
                     f"Failed to init FactorMemory for {key}: {e}", level=ERROR
                 )
                 return False
-        self._write_log(
-            f"Initialized {len(self.factor_memory_instances)} FactorMemory instances.",
-            level=INFO,
-        )
         return True
 
     def _build_dask_computational_graph(self) -> bool:
@@ -310,9 +303,6 @@ class FactorCalculator:
         if not self.dask_tasks and self.flattened_factors:
             self._write_log("Dask graph empty but factors exist.", level=ERROR)
             return False
-        self._write_log(
-            f"Built Dask graph with {len(self.dask_tasks)} tasks.", level=INFO
-        )
         return True
 
     def _execute_batch_dask_graph(self) -> bool:
@@ -331,10 +321,6 @@ class FactorCalculator:
                         optimize_graph=True,
                         scheduler="threads"
                     )
-                self._write_log(
-                    f"Dask computation finished in {time.time() - start_time:.3f}s.",
-                    level=INFO,
-                )
                 errors = 0
                 for key, df_res in zip(self.dask_tasks.keys(), results, strict=False):
                     if df_res is None or not isinstance(df_res, pl.DataFrame):

--- a/vnpy/factor/backtesting/optimizer.py
+++ b/vnpy/factor/backtesting/optimizer.py
@@ -94,7 +94,7 @@ class FactorOptimizer:
             test_rows = test_data["close"].height
             self._write_log(
                 f"Data split into {train_rows} train rows and {test_rows} test rows.",
-                INFO,
+                level=DEBUG,
             )
         except ValueError as e:
             self._write_log(f"Error splitting data: {e}", ERROR)


### PR DESCRIPTION
Further refines logging in the factor backtesting module by removing specific DEBUG-level log messages that were identified as redundant. These changes follow a previous adjustment of INFO logs to DEBUG.

Removed messages include:
- FactorCalculator:
    - Confirmation of cache directory creation.
    - Completion messages for memory initialization, Dask graph building, and Dask computation.
- FactorAnalyser:
    - Completion messages for quantile analysis and QuantStats metrics calculation.
    - Success message for analysis data preparation.

This cleanup aims to make DEBUG level output more concise by relying on the absence of error messages after an operation's initiation log to imply success.

建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 
2. 
3.

## 相关的Issue号（如有）

Close #